### PR TITLE
WIP: Add support for MPS/MLX to use the GPUs on a Apple Silicon Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@
     - Run the following command with your specific cuda version. **This example is for cuda version 11.8, edit the command for your installed version**.
     - `conda install pytorch==2.1.2 torchvision==0.16.2 torchaudio==2.1.2 pytorch-cuda=11.8 -c pytorch -c nvidia`
     - `pip install -r requirements.txt`
+    - MacOS 
+      - Don't do the above, but:
+        ```
+        conda install pytorch==2.1.2 torchvision==0.16.2 torchaudio==2.1.2  -c pytorch 
+        pip install -r requirements.txt 
+        pip install -r requirements-mps.txt
+        pip install --force --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu # when pytorch 2.6/7 is released, this line can be removed
+        pip install --force-reinstall -v "numpy==1.26.3"` # hopefully also not needed in the future
+        ```
+      - And set `DEVICE = "mps"` in your `.env` file
+      - You don't need to uninstall onnxruntime in the next step
 - Make sure, that the onnxruntime-gpu package is installed. Otherwise uninstall onnxruntime and install onnxruntime-gpu (if in doubt, just reinstall onnxruntime-gpu)
     - `pip uninstall onnxruntime`
     - `pip install --force-reinstall onnxruntime-gpu`
@@ -78,10 +89,14 @@
 
 ### Running the Application
 Start the worker and frontend scripts:
-- Linux
+- Linux / MacOS
     - `tmux new -s transcribe_worker`
     - `conda activate transcribo`
-    - `python worker.py`
+    - Linux:
+      - `python worker.py`
+    - MacOS:
+      - The MPS/MLX implementation of all this has some massive memory leaks, so we do restart the worker after every transcription. Patches to prevent this are welcome.
+      - `while true; do python worker.py; done`
     - Exit tmux session with `CTRL-B` and `D`.
     - `tmux new -s transcribe_frontend`
     - `conda activate transcribo`

--- a/requirements-mps.txt
+++ b/requirements-mps.txt
@@ -1,0 +1,4 @@
+mlx_whisper==0.4.1
+torch==2.5.1
+torchaudio==2.5.1
+torchvision==0.20.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,7 @@ pyannote.database==5.0.1
 pyannote.metrics==3.2.1
 pyannote.pipeline==3.0.1
 python-dotenv==1.0.1
-whisperx==3.1.5
+whisperx==3.2.0
 speechbrain==0.5.16
+numpy==1.26.3
+

--- a/src/util.py
+++ b/src/util.py
@@ -1,5 +1,6 @@
 import subprocess
-
+import os
+DEVICE = os.getenv("DEVICE")
 
 def get_length(filename):
     result = subprocess.run(
@@ -26,9 +27,15 @@ def time_estimate(filename, online=True):
             return 1, 1
         run_time = get_length(filename)
         if online:
-            return run_time / 10, run_time
+            if DEVICE == "mps":
+                return run_time / 5, run_time
+            else:
+                return run_time / 10, run_time
         else:
-            return run_time / 6, run_time
+            if DEVICE == "mps":
+                return run_time / 3, run_time
+            else:
+                return run_time / 6, run_time
     except Exception as e:
         print(e)
         return -1, -1


### PR DESCRIPTION
This adds support for using mlx_whisper and pytorch-mps to make it run decently fast on an Apple Silicon based Mac. Not as fast as on an CUDA GPU, but useable fast, IMHO.

Unfortunately there's a big memory leak somewhere and I couldn't figure out how to prevent it. It just exits the worker after each transcription and you should restart the worker afterwards automatically, with eg.

`while true; do python worker.py; done` 

or something like pm2.

I also disabled the `add_language` part, since `detect_language` is not directly supported by mlx_whisper (but if you enable it, it tries a workaround).

With that memory leak workaround, not sure this should be merged. I leave the MR open in case someone wants to use this as it is or even has ideas of how to prevent it.

See the macos parts in the README to get it running on a Mac